### PR TITLE
Add FromString for hexadecimal string values and use error instead panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module lukechampine.com/uint128
 
 go 1.12
+
+require github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Hey @lukechampine 
First of all, thanks for publishing the `uint128` package. I found there is no func for creating `uint128` from hexadecimal values, so I created this PR. And also returning multiple values for error recovery seems better choice (we don't have nested error anywhere). can you please review and accept this PR?