### PR TITLE
Add bits.LeadingZeros equivalent

### DIFF
--- a/uint128.go
+++ b/uint128.go
@@ -216,6 +216,16 @@ func (u Uint128) Rsh(n uint) (s Uint128) {
 	return
 }
 
+// LeadingZeros returns amount of leading zero bits, similarly to bits.LeadingZeros{16,32,64}
+func (u Uint128) LeadingZeros() uint {
+	prefLen := uint(bits.LeadingZeros64(u.hi))
+	if prefLen < 64 {
+		return prefLen
+	}
+
+	return prefLen + uint(bits.LeadingZeros64(u.lo))
+}
+
 // String returns the base-10 representation of u as a string.
 func (u Uint128) String() string {
 	if u.IsZero() {

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -150,6 +150,72 @@ func TestArithmetic(t *testing.T) {
 	}
 }
 
+func TestLeadingZeros(t *testing.T) {
+	tcs := []struct {
+		l     Uint128
+		r     Uint128
+		zeros uint
+	}{
+		{
+			l:     New(0x00, 0xf000000000000000),
+			r:     New(0x00, 0x8000000000000000),
+			zeros: 1,
+		},
+		{
+			l:     New(0x00, 0xf000000000000000),
+			r:     New(0x00, 0xc000000000000000),
+			zeros: 2,
+		},
+		{
+			l:     New(0x00, 0xf000000000000000),
+			r:     New(0x00, 0xe000000000000000),
+			zeros: 3,
+		},
+		{
+			l:     New(0x00, 0xffff000000000000),
+			r:     New(0x00, 0xff00000000000000),
+			zeros: 8,
+		},
+		{
+			l:     New(0x00, 0x000000000000ffff),
+			r:     New(0x00, 0x000000000000ff00),
+			zeros: 56,
+		},
+		{
+			l:     New(0xf000000000000000, 0x01),
+			r:     New(0x4000000000000000, 0x00),
+			zeros: 63,
+		},
+		{
+			l:     New(0xf000000000000000, 0x00),
+			r:     New(0x4000000000000000, 0x00),
+			zeros: 64,
+		},
+		{
+			l:     New(0xf000000000000000, 0x00),
+			r:     New(0x8000000000000000, 0x00),
+			zeros: 65,
+		},
+		{
+			l:     New(0x00, 0x00),
+			r:     New(0x00, 0x00),
+			zeros: 128,
+		},
+		{
+			l:     New(0x01, 0x00),
+			r:     New(0x00, 0x00),
+			zeros: 127,
+		},
+	}
+
+	for _, tc := range tcs {
+		zeros := tc.l.Xor(tc.r).LeadingZeros()
+		if zeros != tc.zeros {
+			t.Errorf("mismatch (expected: %d, got: %d)", tc.zeros, zeros)
+		}
+	}
+}
+
 func TestString(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		x := randUint128()


### PR DESCRIPTION
Should work exactly like bits.LeadingZeros{16,32,64} family.

Why test cases have two xored uints: it's a direct copypaste of my tests for finding matching prefix in two IPv6 addresses.