### PR TITLE
support for big-endian order

### DIFF
--- a/uint128.go
+++ b/uint128.go
@@ -373,8 +373,20 @@ func (u Uint128) String() string {
 
 // PutBytes stores u in b in little-endian order. It panics if len(b) < 16.
 func (u Uint128) PutBytes(b []byte) {
+	// little-endian order is used by default
+	u.PutBytesLE(b)
+}
+
+// PutBytesLE stores u in b in little-endian order. It panics if len(b) < 16.
+func (u Uint128) PutBytesLE(b []byte) {
 	binary.LittleEndian.PutUint64(b[:8], u.Lo)
 	binary.LittleEndian.PutUint64(b[8:], u.Hi)
+}
+
+// PutBytesBE stores u in b in big-endian order. It panics if len(b) < 16.
+func (u Uint128) PutBytesBE(b []byte) {
+	binary.BigEndian.PutUint64(b[:8], u.Hi)
+	binary.BigEndian.PutUint64(b[8:], u.Lo)
 }
 
 // Big returns u as a *big.Int.
@@ -395,11 +407,25 @@ func From64(v uint64) Uint128 {
 	return New(v, 0)
 }
 
-// FromBytes converts b to a Uint128 value.
+// FromBytes converts b to a Uint128 value (little-endian order).
 func FromBytes(b []byte) Uint128 {
+	// little-endian order is used by default
+	return FromBytesLE(b)
+}
+
+// FromBytesLE converts b to a Uint128 value (little-endian order).
+func FromBytesLE(b []byte) Uint128 {
 	return New(
 		binary.LittleEndian.Uint64(b[:8]),
 		binary.LittleEndian.Uint64(b[8:]),
+	)
+}
+
+// FromBytesBE converts b to a Uint128 value (big-endian order).
+func FromBytesBE(b []byte) Uint128 {
+	return New(
+		binary.BigEndian.Uint64(b[8:]),
+		binary.BigEndian.Uint64(b[:8]),
 	)
 }
 

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -29,9 +29,19 @@ func TestUint128(t *testing.T) {
 		}
 
 		b := make([]byte, 16)
-		x.PutBytes(b)
+		x.PutBytes(b) // also check PutBytesLE and FromBytesLE
 		if FromBytes(b) != x {
 			t.Fatal("FromBytes is not the inverse of PutBytes for", x)
+		}
+		for i, n := 0, len(b); i < n/2; i++ { // reverse byte order manually:
+			b[i], b[n-i-1] = b[n-i-1], b[i] // little-endian to big-endian
+		}
+		if FromBytesBE(b) != x {
+			t.Fatal("FromBytesBE is not the inverse of reverse(PutBytes) for", x)
+		}
+		x.PutBytesBE(b)
+		if FromBytesBE(b) != x {
+			t.Fatal("FromBytesBE is not the inverse of PutBytesBE for", x)
 		}
 
 		if !x.Equals(x) {


### PR DESCRIPTION
This might be useful for example for IPv6 address arithmetic.
Now user can explicitly select the byte order:
 - `FromBytesBE` and `u.PutBytesBE` are used for big-endian order
 - `FromBytesLE` and `u.PutBytesLE` are used for little-endian order