### PR TITLE
fix overflow detection bug in `u.Mul`

### DIFF
--- a/uint128.go
+++ b/uint128.go
@@ -177,9 +177,10 @@ func (u Uint128) Mul(v Uint128) Uint128 {
 	hi, lo := bits.Mul64(u.Lo, v.Lo)
 	p0, p1 := bits.Mul64(u.Hi, v.Lo)
 	p2, p3 := bits.Mul64(u.Lo, v.Hi)
+	p4, p5 := bits.Mul64(u.Hi, v.Hi)
 	hi, c0 := bits.Add64(hi, p1, 0)
-	hi, c1 := bits.Add64(hi, p3, 0)
-	if p0 != 0 || p2 != 0 || c0 != 0 || c1 != 0 {
+	hi, c1 := bits.Add64(hi, p3, c0)
+	if p0 != 0 || p2 != 0 || p4 != 0 || p5 != 0 || c1 != 0 {
 		panic("overflow")
 	}
 	return Uint128{lo, hi}

--- a/uint128.go
+++ b/uint128.go
@@ -177,10 +177,12 @@ func (u Uint128) Mul(v Uint128) Uint128 {
 	hi, lo := bits.Mul64(u.Lo, v.Lo)
 	p0, p1 := bits.Mul64(u.Hi, v.Lo)
 	p2, p3 := bits.Mul64(u.Lo, v.Hi)
-	p4, p5 := bits.Mul64(u.Hi, v.Hi)
+	// p4, p5 := bits.Mul64(u.Hi, v.Hi)
+	// p4 and p5 both are zero only
+	// if one u.Hi or v.Hi is zero
 	hi, c0 := bits.Add64(hi, p1, 0)
 	hi, c1 := bits.Add64(hi, p3, c0)
-	if p0 != 0 || p2 != 0 || p4 != 0 || p5 != 0 || c1 != 0 {
+	if (u.Hi != 0 && v.Hi != 0) || p0 != 0 || p2 != 0 || c1 != 0 {
 		panic("overflow")
 	}
 	return Uint128{lo, hi}

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -211,6 +211,7 @@ func TestOverflowAndUnderflow(t *testing.T) {
 	checkPanic(func() { _ = z.Sub64(math.MaxInt64) }, "underflow")
 	checkPanic(func() { _ = x.Mul(y) }, "overflow")
 	checkPanic(func() { _ = New(0, 10).Mul(New(0, 10)) }, "overflow")
+	checkPanic(func() { _ = New(0, 1).Mul(New(0, 1)) }, "overflow")
 	checkPanic(func() { _ = x.Mul64(math.MaxInt64) }, "overflow")
 }
 


### PR DESCRIPTION
For example `New(0, 10).Mul(New(0, 10))` should panic.
We also have to check multiplication of high parts.
Without that check result is zero which is incorrect.