### PR TITLE
add AppendBytes(BE) methods

### DIFF
--- a/uint128.go
+++ b/uint128.go
@@ -383,6 +383,20 @@ func (u Uint128) PutBytesBE(b []byte) {
 	binary.BigEndian.PutUint64(b[8:], u.Lo)
 }
 
+// AppendBytes appends u to b in little-endian order and returns the extended buffer.
+func (u Uint128) AppendBytes(b []byte) []byte {
+	b = binary.LittleEndian.AppendUint64(b, u.Lo)
+	b = binary.LittleEndian.AppendUint64(b, u.Hi)
+	return b
+}
+
+// AppendBytesBE appends u to b in big-endian order and returns the extended buffer.
+func (u Uint128) AppendBytesBE(b []byte) []byte {
+	b = binary.BigEndian.AppendUint64(b, u.Hi)
+	b = binary.BigEndian.AppendUint64(b, u.Lo)
+	return b
+}
+
 // Big returns u as a *big.Int.
 func (u Uint128) Big() *big.Int {
 	i := new(big.Int).SetUint64(u.Hi)

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -490,6 +490,42 @@ func TestFromBytesBE(t *testing.T) {
 	}
 }
 
+func TestAppendBytes(t *testing.T) {
+	u := randUint128()
+	v := randUint128()
+
+	b := u.AppendBytes(nil)
+	b = v.AppendBytes(b)
+
+	if len(b) != 2*16 {
+		t.Fatal("AppendBytes twice should append 32 bytes, got:", len(b))
+	}
+	if FromBytes(b) != u {
+		t.Fatal("FromBytes is not the inverse of AppendBytes for", u)
+	}
+	if FromBytes(b[16:]) != v {
+		t.Fatal("FromBytes is not the inverse of AppendBytes for", v)
+	}
+}
+
+func TestAppendBytesBE(t *testing.T) {
+	u := randUint128()
+	v := randUint128()
+
+	b := u.AppendBytesBE(nil)
+	b = v.AppendBytesBE(b)
+
+	if len(b) != 2*16 {
+		t.Fatal("AppendBytesBE twice should append 32 bytes, got:", len(b))
+	}
+	if FromBytesBE(b) != u {
+		t.Fatal("FromBytesBE is not the inverse of AppendBytesBE for", u)
+	}
+	if FromBytesBE(b[16:]) != v {
+		t.Fatal("FromBytesBE is not the inverse of AppendBytesBE for", v)
+	}
+}
+
 func TestMarshalText(t *testing.T) {
 	type testStruct struct {
 		Foo Uint128


### PR DESCRIPTION
These methods simplify constructing byte slices out of uint128s and are similar to the [`AppendByteOrder`](https://pkg.go.dev/encoding/binary#AppendByteOrder) methods added to `encoding/binary` in go1.19.